### PR TITLE
Added: Teste unitário adicionado

### DIFF
--- a/features/favorite/src/main/java/com/example/favorite/presentation/FavoriteFragment.kt
+++ b/features/favorite/src/main/java/com/example/favorite/presentation/FavoriteFragment.kt
@@ -81,7 +81,7 @@ class FavoriteFragment : Fragment() {
     }
 
     private fun onClickBtnTryAgain() {
-        viewModel.getFavoriteList()
+        viewModel.tryAgain()
     }
 }
     

--- a/features/favorite/src/main/java/com/example/favorite/presentation/FavoriteViewModel.kt
+++ b/features/favorite/src/main/java/com/example/favorite/presentation/FavoriteViewModel.kt
@@ -28,4 +28,8 @@ internal class FavoriteViewModel(private val getFavoriteListUseCase: GetFavorite
                 }
             ).handleDisposable()
     }
+
+    fun tryAgain() {
+        getFavoriteList()
+    }
 }


### PR DESCRIPTION
# **Descrição**
Teste unitário adicionado para validar a funcionalidade de tentar novamente sempre que ocorre algum erro na chamada da API.