### PR TITLE
Added: Inclusão de teste instrumentado para o cenário de lista vazia

### DIFF
--- a/features/favorite/src/androidTest/java/com/example/favorite/FavoriteFragmentRobot.kt
+++ b/features/favorite/src/androidTest/java/com/example/favorite/FavoriteFragmentRobot.kt
@@ -1,6 +1,5 @@
 package com.example.favorite
 
-
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
@@ -8,7 +7,10 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.*
+import com.example.favorite.domain.GetFavoriteListUseCase
 import com.example.favorite.presentation.FavoriteFragment
+import org.koin.core.context.loadKoinModules
+import org.koin.dsl.module
 
 class FavoriteFragmentRobot {
     fun launchFragment() {
@@ -29,4 +31,19 @@ class FavoriteFragmentRobot {
 
     private fun getView(id: Int) = onView(withId(id))
 
+    fun loadModulesOfSuccessfulScenario() {
+        loadKoinModules(
+            module(override = true) {
+                factory<GetFavoriteListUseCase> { StubGetFavoriteListUseCaseSuccessfulScenario }
+            }
+        )
+    }
+
+    fun loadModulesOfEmptyListScenario() {
+        loadKoinModules(
+            module(override = true) {
+                factory<GetFavoriteListUseCase> { StubGetFavoriteListUseCaseEmptyListScenario }
+            }
+        )
+    }
 }

--- a/features/favorite/src/androidTest/java/com/example/favorite/FavoriteFragmentTest.kt
+++ b/features/favorite/src/androidTest/java/com/example/favorite/FavoriteFragmentTest.kt
@@ -2,29 +2,23 @@ package com.example.favorite
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.favorite.di.FavoriteModule
-import com.example.favorite.domain.GetFavoriteListUseCase
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
-import org.koin.dsl.module
 
 @RunWith(AndroidJUnit4::class)
 class FavoriteFragmentTest {
+
     private val robot = FavoriteFragmentRobot()
 
     @Before
     fun setupKoin() {
-        startKoin {  }
-        FavoriteModule().load()
-        loadKoinModules(
-            module(override = true) {
-                factory<GetFavoriteListUseCase> { StubGetFavoriteListUseCase }
-            }
-        )
+        startKoin {
+            FavoriteModule().load()
+        }
     }
 
     @After
@@ -34,15 +28,23 @@ class FavoriteFragmentTest {
 
     @Test
     fun whenFragmentIsStarted_shouldDisplayRecyclerView() {
+        robot.loadModulesOfSuccessfulScenario()
         robot.launchFragment()
         robot.checkListVisibility(R.id.rvFavoriteStoresList)
     }
 
     @Test
     fun whenFragmentIsStarted_shouldDisplayRecyclerViewItemsCorrectly() {
+        robot.loadModulesOfSuccessfulScenario()
         robot.launchFragment()
-
         robot.scrollToItem("Lojas Americanas",  R.id.rvFavoriteStoresList)
         robot.scrollToItem("Magalu",  R.id.rvFavoriteStoresList)
+    }
+
+    @Test
+    fun whenFragmentIsStarted_shouldDisplayEmptyListText() {
+        robot.loadModulesOfEmptyListScenario()
+        robot.launchFragment()
+        robot.checkListVisibility(R.id.txtEmptyResult)
     }
 }

--- a/features/favorite/src/androidTest/java/com/example/favorite/StubGetFavoriteListUseCaseEmptyListScenario.kt
+++ b/features/favorite/src/androidTest/java/com/example/favorite/StubGetFavoriteListUseCaseEmptyListScenario.kt
@@ -1,0 +1,11 @@
+package com.example.favorite
+
+import com.example.favorite.domain.GetFavoriteListUseCase
+import com.example.favorite.domain.entity.FavoriteStore
+import io.reactivex.Single
+
+object StubGetFavoriteListUseCaseEmptyListScenario : GetFavoriteListUseCase {
+    override fun invoke() = Single.just(
+        emptyList<FavoriteStore>()
+    )
+}

--- a/features/favorite/src/androidTest/java/com/example/favorite/StubGetFavoriteListUseCaseSuccessfulScenario.kt
+++ b/features/favorite/src/androidTest/java/com/example/favorite/StubGetFavoriteListUseCaseSuccessfulScenario.kt
@@ -4,7 +4,7 @@ import com.example.favorite.domain.GetFavoriteListUseCase
 import com.example.favorite.domain.entity.FavoriteStore
 import io.reactivex.Single
 
-object StubGetFavoriteListUseCase : GetFavoriteListUseCase {
+object StubGetFavoriteListUseCaseSuccessfulScenario : GetFavoriteListUseCase {
     override fun invoke() = Single.just(
         listOf(
             FavoriteStore(


### PR DESCRIPTION
#  **Descrição**
Este PR adiciona o teste instrumentado para o cenário de lista vazia retornando do usecase `GetFavoriteListUseCase`, com a inclusão do Stub `StubGetFavoriteListUseCaseEmptyListScenario`. Também inclui funções de carregamento de dependências do Koin na classe Robot que são utilizadas para diferentes cenários nos testes.